### PR TITLE
Add format options for !color_animation

### DIFF
--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
@@ -284,6 +284,26 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
         @Getter
         @Setter
         private MarkedFloatProperty speed;
+    
+        @Getter
+        @Setter
+        private MarkedBooleanProperty bold;
+    
+        @Getter
+        @Setter
+        private MarkedBooleanProperty italic;
+    
+        @Getter
+        @Setter
+        private MarkedBooleanProperty underline;
+    
+        @Getter
+        @Setter
+        private MarkedBooleanProperty strikethrough;
+    
+        @Getter
+        @Setter
+        private MarkedBooleanProperty magic;
 
         public ColorAnimation() {
             setParameters(new MarkedIntegerProperty(1));
@@ -292,6 +312,7 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
         @Override
         public PlaceholderBuilder<?, ?> bindArgs(PlaceholderBuilder<Context, ?> builder, List<PlaceholderArg> args, TemplateCreationContext tcc) {
             List<TextColor> colors = new ArrayList<>();
+            List<TextColor> formats = new ArrayList<>();
 
             if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "colors", this.colors, getStartMark())
                     && ConfigValidationUtil.checkNotEmpty(tcc,  "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark())) {
@@ -301,6 +322,26 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
                         colors.add(TextColor.parse(color.getValue(), tcc, color.getStartMark()));
                     }
                 }
+            }
+            
+            if (this.bold != null && this.bold.isValue()) {
+                formats.add(TextColor.FORMAT_BOLD);
+            }
+            
+            if (this.italic != null && this.italic.isValue()) {
+                formats.add(TextColor.FORMAT_ITALIC);
+            }
+            
+            if (this.underline != null && this.underline.isValue()) {
+                formats.add(TextColor.FORMAT_UNDERLINE);
+            }
+            
+            if (this.strikethrough != null && this.strikethrough.isValue()) {
+                formats.add(TextColor.FORMAT_STRIKETHROUGH);
+            }
+            
+            if (this.magic != null && this.magic.isValue()) {
+                formats.add(TextColor.FORMAT_MAGIC);
             }
 
             OptionalInt distance = OptionalInt.empty();
@@ -317,7 +358,7 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
 
             OptionalInt finalDistance = distance;
             float finalSpeed = speed;
-            return builder.acquireData(() -> new CustomPlaceholderColorAnimation(textTemplate, colors, finalDistance, finalSpeed), TypeToken.STRING, textTemplate.requiresViewerContext());
+            return builder.acquireData(() -> new CustomPlaceholderColorAnimation(textTemplate, colors, formats, finalDistance, finalSpeed), TypeToken.STRING, textTemplate.requiresViewerContext());
         }
     }
 

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
@@ -287,23 +287,7 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
     
         @Getter
         @Setter
-        private MarkedBooleanProperty bold;
-    
-        @Getter
-        @Setter
-        private MarkedBooleanProperty italic;
-    
-        @Getter
-        @Setter
-        private MarkedBooleanProperty underline;
-    
-        @Getter
-        @Setter
-        private MarkedBooleanProperty strikethrough;
-    
-        @Getter
-        @Setter
-        private MarkedBooleanProperty magic;
+        private MarkedListProperty<MarkedStringProperty> formats;
 
         public ColorAnimation() {
             setParameters(new MarkedIntegerProperty(1));
@@ -314,8 +298,7 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
             List<TextColor> colors = new ArrayList<>();
             List<TextColor> formats = new ArrayList<>();
 
-            if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "colors", this.colors, getStartMark())
-                    && ConfigValidationUtil.checkNotEmpty(tcc,  "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark())) {
+            if (ConfigValidationUtil.checkNotEmpty(tcc,  "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark())) {
 
                 for (MarkedStringProperty color : this.colors) {
                     if (color != null) {
@@ -324,24 +307,14 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
                 }
             }
             
-            if (this.bold != null && this.bold.isValue()) {
-                formats.add(TextColor.FORMAT_BOLD);
-            }
-            
-            if (this.italic != null && this.italic.isValue()) {
-                formats.add(TextColor.FORMAT_ITALIC);
-            }
-            
-            if (this.underline != null && this.underline.isValue()) {
-                formats.add(TextColor.FORMAT_UNDERLINE);
-            }
-            
-            if (this.strikethrough != null && this.strikethrough.isValue()) {
-                formats.add(TextColor.FORMAT_STRIKETHROUGH);
-            }
-            
-            if (this.magic != null && this.magic.isValue()) {
-                formats.add(TextColor.FORMAT_MAGIC);
+            if (ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "formats", this.formats, this.formats.getStartMark())) {
+                
+                for (MarkedStringProperty format : this.formats) {
+                    TextColor tc = TextColor.parseFormat(format.getValue(), tcc, format.getStartMark());
+                    if (tc != null) {
+                        formats.add(tc);
+                    }
+                }
             }
 
             OptionalInt distance = OptionalInt.empty();

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
@@ -287,7 +287,7 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
     
         @Getter
         @Setter
-        private MarkedListProperty<MarkedStringProperty> formats;
+        private MarkedStringProperty formats;
 
         public ColorAnimation() {
             setParameters(new MarkedIntegerProperty(1));
@@ -296,7 +296,6 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
         @Override
         public PlaceholderBuilder<?, ?> bindArgs(PlaceholderBuilder<Context, ?> builder, List<PlaceholderArg> args, TemplateCreationContext tcc) {
             List<TextColor> colors = new ArrayList<>();
-            List<TextColor> formats = new ArrayList<>();
 
             if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "colors", this.colors, getStartMark())
                 && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark())) {
@@ -308,17 +307,6 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
                 }
             }
             
-            if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "formats", this.formats, getStartMark())
-                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "formats", this.formats, this.formats.getStartMark())) {
-                
-                for (MarkedStringProperty format : this.formats) {
-                    TextColor tc = TextColor.parseFormat(format.getValue(), tcc, getStartMark());
-                    if (tc != null) {
-                        formats.add(tc);
-                    }
-                }
-            }
-
             OptionalInt distance = OptionalInt.empty();
             if (this.distance != null) {
                 distance = OptionalInt.of(this.distance.getValue());
@@ -333,7 +321,7 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
 
             OptionalInt finalDistance = distance;
             float finalSpeed = speed;
-            return builder.acquireData(() -> new CustomPlaceholderColorAnimation(textTemplate, colors, formats, finalDistance, finalSpeed), TypeToken.STRING, textTemplate.requiresViewerContext());
+            return builder.acquireData(() -> new CustomPlaceholderColorAnimation(textTemplate, colors, formats.getValue(), finalDistance, finalSpeed), TypeToken.STRING, textTemplate.requiresViewerContext());
         }
     }
 

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
@@ -298,8 +298,8 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
             List<TextColor> colors = new ArrayList<>();
             List<TextColor> formats = new ArrayList<>();
 
-            if (ConfigValidationUtil.checkNotNull(tcc,  "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark()) 
-                && ConfigValidationUtil.checkNotEmpty(tcc,  "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark())) {
+            if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "colors", this.colors, getStartMark())
+                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "colors", this.colors, getStartMark())) {
 
                 for (MarkedStringProperty color : this.colors) {
                     if (color != null) {
@@ -308,11 +308,11 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
                 }
             }
             
-            if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "formats", this.formats, this.formats.getStartMark()) 
-                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "formats", this.formats, this.formats.getStartMark())) {
+            if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "formats", this.formats, getStartMark())
+                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "formats", this.formats, getStartMark())) {
                 
                 for (MarkedStringProperty format : this.formats) {
-                    TextColor tc = TextColor.parseFormat(format.getValue(), tcc, format.getStartMark());
+                    TextColor tc = TextColor.parseFormat(format.getValue(), tcc, getStartMark());
                     if (tc != null) {
                         formats.add(tc);
                     }

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
@@ -299,7 +299,7 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
             List<TextColor> formats = new ArrayList<>();
 
             if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "colors", this.colors, getStartMark())
-                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "colors", this.colors, getStartMark())) {
+                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark())) {
 
                 for (MarkedStringProperty color : this.colors) {
                     if (color != null) {
@@ -309,7 +309,7 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
             }
             
             if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "formats", this.formats, getStartMark())
-                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "formats", this.formats, getStartMark())) {
+                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "formats", this.formats, this.formats.getStartMark())) {
                 
                 for (MarkedStringProperty format : this.formats) {
                     TextColor tc = TextColor.parseFormat(format.getValue(), tcc, getStartMark());

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
@@ -321,7 +321,8 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
 
             OptionalInt finalDistance = distance;
             float finalSpeed = speed;
-            return builder.acquireData(() -> new CustomPlaceholderColorAnimation(textTemplate, colors, sanitizeFormats(formats.getValue()), finalDistance, finalSpeed), TypeToken.STRING, textTemplate.requiresViewerContext());
+            String finalFormats = formats == null ? "" : sanitizeFormats(formats.getValue());
+            return builder.acquireData(() -> new CustomPlaceholderColorAnimation(textTemplate, colors, finalFormats, finalDistance, finalSpeed), TypeToken.STRING, textTemplate.requiresViewerContext());
         }
         
         // Make sure only valid formatting codes are provided.

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
@@ -321,7 +321,31 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
 
             OptionalInt finalDistance = distance;
             float finalSpeed = speed;
-            return builder.acquireData(() -> new CustomPlaceholderColorAnimation(textTemplate, colors, formats.getValue(), finalDistance, finalSpeed), TypeToken.STRING, textTemplate.requiresViewerContext());
+            return builder.acquireData(() -> new CustomPlaceholderColorAnimation(textTemplate, colors, sanitizeFormats(formats.getValue()), finalDistance, finalSpeed), TypeToken.STRING, textTemplate.requiresViewerContext());
+        }
+        
+        // Make sure only valid formatting codes are provided.
+        private String sanitizeFormats(String formats) {
+            if (formats == null) {
+                return "";
+            }
+            
+            char[] chars = formats.toCharArray();
+            StringBuilder sb = new StringBuilder(formats.length());
+            
+            for (int i = 0; i < chars.length; i++) {
+                char c = chars[i];
+                
+                if (c == '&' && i++ < chars.length) {
+                    char code = Character.toLowerCase(chars[i]);
+                    
+                    if (code == 'l' || code == 'm' || code == 'n' || code == 'o' || code == 'k') {
+                        sb.append(c).append(code);
+                    }
+                }
+            }
+            
+            return sb.toString();
         }
     }
 

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/CustomPlaceholderConfiguration.java
@@ -298,7 +298,8 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
             List<TextColor> colors = new ArrayList<>();
             List<TextColor> formats = new ArrayList<>();
 
-            if (ConfigValidationUtil.checkNotEmpty(tcc,  "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark())) {
+            if (ConfigValidationUtil.checkNotNull(tcc,  "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark()) 
+                && ConfigValidationUtil.checkNotEmpty(tcc,  "!color_animation custom placeholder", "colors", this.colors, this.colors.getStartMark())) {
 
                 for (MarkedStringProperty color : this.colors) {
                     if (color != null) {
@@ -307,7 +308,8 @@ public abstract class CustomPlaceholderConfiguration extends MarkedPropertyBase 
                 }
             }
             
-            if (ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "formats", this.formats, this.formats.getStartMark())) {
+            if (ConfigValidationUtil.checkNotNull(tcc, "!color_animation custom placeholder", "formats", this.formats, this.formats.getStartMark()) 
+                && ConfigValidationUtil.checkNotEmpty(tcc, "!color_animation custom placeholder", "formats", this.formats, this.formats.getStartMark())) {
                 
                 for (MarkedStringProperty format : this.formats) {
                     TextColor tc = TextColor.parseFormat(format.getValue(), tcc, format.getStartMark());

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/util/ConfigValidationUtil.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/util/ConfigValidationUtil.java
@@ -39,10 +39,6 @@ public class ConfigValidationUtil {
     }
 
     public static boolean checkNotEmpty(TemplateCreationContext tcc, String context, String attributeName, Collection<?> value, Mark mark) {
-        if (!checkNotNull(tcc, context, attributeName, value, mark)) {
-            return false;
-        }
-        
         if (value.isEmpty()) {
             tcc.getErrorHandler().addError("Failed to configure " + context + ", " + attributeName + " is empty.", mark);
             return false;

--- a/src/main/java/de/codecrafter47/taboverlay/config/dsl/util/ConfigValidationUtil.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/dsl/util/ConfigValidationUtil.java
@@ -39,6 +39,10 @@ public class ConfigValidationUtil {
     }
 
     public static boolean checkNotEmpty(TemplateCreationContext tcc, String context, String attributeName, Collection<?> value, Mark mark) {
+        if (!checkNotNull(tcc, context, attributeName, value, mark)) {
+            return false;
+        }
+        
         if (value.isEmpty()) {
             tcc.getErrorHandler().addError("Failed to configure " + context + ", " + attributeName + " is empty.", mark);
             return false;

--- a/src/main/java/de/codecrafter47/taboverlay/config/misc/TextColor.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/misc/TextColor.java
@@ -42,6 +42,12 @@ public class TextColor {
     public static final TextColor COLOR_DARK_GREEN = new TextColor(0, 170, 0, "&2");
     public static final TextColor COLOR_DARK_BLUE = new TextColor(0, 0, 170, "&1");
     public static final TextColor COLOR_BLACK = new TextColor(0, 0, 0, "&0");
+    
+    public static final TextColor FORMAT_BOLD = new TextColor("&l");
+    public static final TextColor FORMAT_ITALIC = new TextColor("&o");
+    public static final TextColor FORMAT_UNDERLINE = new TextColor("&n");
+    public static final TextColor FORMAT_STRIKETHROUGH = new TextColor("&m");
+    public static final TextColor FORMAT_MAGIC = new TextColor("&k");
 
     public static TextColor parse(String color, TemplateCreationContext tcc, Mark mark) {
         char c;
@@ -135,6 +141,13 @@ public class TextColor {
         this.r = r;
         this.g = g;
         this.b = b;
+        this.formatCode = formatCode;
+    }
+    
+    public TextColor(String formatCode){
+        this.r = -1;
+        this.g = -1;
+        this.b = -1;
         this.formatCode = formatCode;
     }
 }

--- a/src/main/java/de/codecrafter47/taboverlay/config/misc/TextColor.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/misc/TextColor.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import org.yaml.snakeyaml.error.Mark;
 
 import java.awt.*;
+import java.util.Locale;
 
 @Getter
 public class TextColor {
@@ -109,6 +110,28 @@ public class TextColor {
         tcc.getErrorHandler().addWarning("Specified color " + color + " does not match expected format.\n" +
                 "Expected a formatting code (e.g. &7) or a hex color (e.g. #012345).", mark);
         return COLOR_WHITE;
+    }
+    
+    public static TextColor parseFormat(String format, TemplateCreationContext tcc, Mark mark) {
+        if (format == null) {
+            return null;
+        }
+        
+        switch (format.toUpperCase(Locale.ROOT)) {
+            case "BOLD":
+                return FORMAT_BOLD;
+            case "ITALIC":
+                return FORMAT_ITALIC;
+            case "UNDERLINE":
+                return FORMAT_UNDERLINE;
+            case "STRIKETHROUGH":
+                return FORMAT_STRIKETHROUGH;
+            case "MAGIC":
+                return FORMAT_MAGIC;
+        }
+        tcc.getErrorHandler().addWarning("Specified format " + format + " does not match expected format.\n" +
+                "Expected a format name (e.g. BOLD).", mark);
+        return null;
     }
 
     public static TextColor interpolateLinear(TextColor a, TextColor b, double x) {

--- a/src/main/java/de/codecrafter47/taboverlay/config/misc/TextColor.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/misc/TextColor.java
@@ -21,9 +21,6 @@ import de.codecrafter47.taboverlay.config.template.TemplateCreationContext;
 import lombok.Getter;
 import org.yaml.snakeyaml.error.Mark;
 
-import java.awt.*;
-import java.util.Locale;
-
 @Getter
 public class TextColor {
 
@@ -43,12 +40,6 @@ public class TextColor {
     public static final TextColor COLOR_DARK_GREEN = new TextColor(0, 170, 0, "&2");
     public static final TextColor COLOR_DARK_BLUE = new TextColor(0, 0, 170, "&1");
     public static final TextColor COLOR_BLACK = new TextColor(0, 0, 0, "&0");
-    
-    public static final TextColor FORMAT_BOLD = new TextColor("&l");
-    public static final TextColor FORMAT_ITALIC = new TextColor("&o");
-    public static final TextColor FORMAT_UNDERLINE = new TextColor("&n");
-    public static final TextColor FORMAT_STRIKETHROUGH = new TextColor("&m");
-    public static final TextColor FORMAT_MAGIC = new TextColor("&k");
 
     public static TextColor parse(String color, TemplateCreationContext tcc, Mark mark) {
         char c;
@@ -111,28 +102,6 @@ public class TextColor {
                 "Expected a formatting code (e.g. &7) or a hex color (e.g. #012345).", mark);
         return COLOR_WHITE;
     }
-    
-    public static TextColor parseFormat(String format, TemplateCreationContext tcc, Mark mark) {
-        if (format == null) {
-            return null;
-        }
-        
-        switch (format.toUpperCase(Locale.ROOT)) {
-            case "BOLD":
-                return FORMAT_BOLD;
-            case "ITALIC":
-                return FORMAT_ITALIC;
-            case "UNDERLINE":
-                return FORMAT_UNDERLINE;
-            case "STRIKETHROUGH":
-                return FORMAT_STRIKETHROUGH;
-            case "MAGIC":
-                return FORMAT_MAGIC;
-        }
-        tcc.getErrorHandler().addWarning("Specified format " + format + " does not match expected format.\n" +
-                "Expected a format name (e.g. BOLD).", mark);
-        return null;
-    }
 
     public static TextColor interpolateLinear(TextColor a, TextColor b, double x) {
         double rb = x;
@@ -164,13 +133,6 @@ public class TextColor {
         this.r = r;
         this.g = g;
         this.b = b;
-        this.formatCode = formatCode;
-    }
-    
-    public TextColor(String formatCode){
-        this.r = -1;
-        this.g = -1;
-        this.b = -1;
         this.formatCode = formatCode;
     }
 }

--- a/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
@@ -89,7 +89,7 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
             TextColor b = colors.get((ia + 1) % colors.size());
             TextColor c = TextColor.interpolateSine(a, b, sd - ia);
             sb.append(c.getFormatCode());
-            sb.append(sanitizeFormats(formats));
+            sb.append(formats);
             sb.appendCodePoint(text.codePointAt(i));
             d += ChatFormat.getCharWidth(text.codePointAt(i));
         }
@@ -124,28 +124,5 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
         if (hasListener()) {
             getListener().run();
         }
-    }
-    
-    // Makes sure the provided Format String is valid formatting codes.
-    private String sanitizeFormats(String formats) {
-        if (formats == null || formats.isEmpty()) {
-            return "";
-        }
-        
-        char[] chars = formats.toCharArray();
-        StringBuilder sb = new StringBuilder(formats.length());
-        for (int i = 0; i < chars.length; i++) {
-            char chr = Character.toLowerCase(chars[i]);
-            
-            if (chr == '&' && i++ < chars.length) {
-                char code = chars[i];
-                
-                if(code == 'l' || code == 'm' || code == 'n' || code == 'o' || code == 'k') {
-                    sb.append(chr).append(code);
-                }
-            }
-        }
-        
-        return sb.toString();
     }
 }

--- a/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
@@ -35,7 +35,7 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
     private Future<?> task;
     private TextView textView;
     private final List<TextColor> colors;
-    private final List<TextColor> formats;
+    private final String formats;
     private final OptionalInt distance;
     private final float speed;
     private String text;
@@ -44,7 +44,7 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
     private float period;
     private String replacement;
 
-    public CustomPlaceholderColorAnimation(TextTemplate textTemplate, List<TextColor> colors, List<TextColor> formats, OptionalInt distance, float speed) {
+    public CustomPlaceholderColorAnimation(TextTemplate textTemplate, List<TextColor> colors, String formats, OptionalInt distance, float speed) {
         this.textView = textTemplate.instantiate();
         this.colors = colors;
         this.formats = formats;
@@ -89,9 +89,7 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
             TextColor b = colors.get((ia + 1) % colors.size());
             TextColor c = TextColor.interpolateSine(a, b, sd - ia);
             sb.append(c.getFormatCode());
-            for (TextColor format : formats) {
-                sb.append(format.getFormatCode());
-            }
+            sb.append(sanitizeFormats(formats));
             sb.appendCodePoint(text.codePointAt(i));
             d += ChatFormat.getCharWidth(text.codePointAt(i));
         }
@@ -126,5 +124,28 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
         if (hasListener()) {
             getListener().run();
         }
+    }
+    
+    // Makes sure the provided Format String is valid formatting codes.
+    private String sanitizeFormats(String formats) {
+        if (formats == null || formats.isEmpty()) {
+            return "";
+        }
+        
+        char[] chars = formats.toCharArray();
+        StringBuilder sb = new StringBuilder(formats.length());
+        for (int i = 0; i < chars.length; i++) {
+            char chr = Character.toLowerCase(chars[i]);
+            
+            if (chr == '&' && i++ < chars.length) {
+                char code = chars[i];
+                
+                if(code == 'l' || code == 'm' || code == 'n' || code == 'o' || code == 'k') {
+                    sb.append(chr).append(code);
+                }
+            }
+        }
+        
+        return sb.toString();
     }
 }

--- a/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
@@ -57,7 +57,7 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
         if (distance.isPresent()) {
             effectiveDistance = distance.getAsInt();
         } else {
-            effectiveDistance = ChatFormat.formattedTextLength(text) / ((colors.size() - 1) + (formats.size() - 1));
+            effectiveDistance = ChatFormat.formattedTextLength(text) / (colors.size() - 1);
         }
         period = effectiveDistance * colors.size();
         updateReplacement();

--- a/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
@@ -80,7 +80,7 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
     }
 
     private void updateReplacement() {
-        StringBuilder sb = new StringBuilder(text.length() * 9);
+        StringBuilder sb = new StringBuilder(text.length() * (9 + formats.length()));
         double d = pos;
         for (int i = 0; i < text.length(); i += Character.charCount(text.codePointAt(i))) {
             double sd = d / effectiveDistance;

--- a/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
+++ b/src/main/java/de/codecrafter47/taboverlay/config/placeholder/CustomPlaceholderColorAnimation.java
@@ -35,6 +35,7 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
     private Future<?> task;
     private TextView textView;
     private final List<TextColor> colors;
+    private final List<TextColor> formats;
     private final OptionalInt distance;
     private final float speed;
     private String text;
@@ -43,9 +44,10 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
     private float period;
     private String replacement;
 
-    public CustomPlaceholderColorAnimation(TextTemplate textTemplate, List<TextColor> colors, OptionalInt distance, float speed) {
+    public CustomPlaceholderColorAnimation(TextTemplate textTemplate, List<TextColor> colors, List<TextColor> formats, OptionalInt distance, float speed) {
         this.textView = textTemplate.instantiate();
         this.colors = colors;
+        this.formats = formats;
         this.distance = distance;
         this.speed = speed;
     }
@@ -55,7 +57,7 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
         if (distance.isPresent()) {
             effectiveDistance = distance.getAsInt();
         } else {
-            effectiveDistance = ChatFormat.formattedTextLength(text) / (colors.size() - 1);
+            effectiveDistance = ChatFormat.formattedTextLength(text) / ((colors.size() - 1) + (formats.size() - 1));
         }
         period = effectiveDistance * colors.size();
         updateReplacement();
@@ -87,6 +89,9 @@ public class CustomPlaceholderColorAnimation extends AbstractActiveElement<Runna
             TextColor b = colors.get((ia + 1) % colors.size());
             TextColor c = TextColor.interpolateSine(a, b, sd - ia);
             sb.append(c.getFormatCode());
+            for (TextColor format : formats) {
+                sb.append(format.getFormatCode());
+            }
             sb.appendCodePoint(text.codePointAt(i));
             d += ChatFormat.getCharWidth(text.codePointAt(i));
         }


### PR DESCRIPTION
Please, please, PLEASE give feedback on this!
I'm not sure if I understand the system good enough to have made the best option available here...

The goal is to add boolean options to enable individual formatting options to a `!color_animation`
If everything works as I assume, should this now allow a placeholder like this:

```yaml
example:
  !color_animation
  colors: ['#abcdef', '#123456']
  distance: 5
  speed: 1
  bold: true
  italic: true
  underline: false # Not needed as it defaults to false anyways... Just to demonstrate.
```