### PR TITLE
Add option for default text in components

### DIFF
--- a/config/src/main/java/de/codecrafter47/taboverlay/config/dsl/RectangularTabOverlayTemplateConfiguration.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/dsl/RectangularTabOverlayTemplateConfiguration.java
@@ -35,6 +35,8 @@ public class RectangularTabOverlayTemplateConfiguration extends AbstractTabOverl
     private IconTemplateConfiguration defaultIcon;
 
     private PingTemplateConfiguration defaultPing = PingTemplateConfiguration.ZERO;
+    
+    private TextTemplateConfiguration defaultText = TextTemplateConfiguration.DEFAULT;
 
     private ComponentConfiguration components;
 
@@ -78,6 +80,9 @@ public class RectangularTabOverlayTemplateConfiguration extends AbstractTabOverl
         }
         if (ConfigValidationUtil.checkNotNull(tcc, "RECTANGULAR tab overlay", "defaultPing", defaultPing, null)) {
             child.setDefaultPing(defaultPing.toTemplate(tcc));
+        }
+        if (ConfigValidationUtil.checkNotNull(tcc, "RECTANGULAR tab overlay", "defaultText", defaultText, null)) {
+            child.setDefaultText(defaultText.toTemplate(tcc));
         }
         if (ConfigValidationUtil.checkNotNull(tcc, "RECTANGULAR tab overlay", "components", components, null)) {
             ComponentTemplate contentRoot = components.toTemplate(child);


### PR DESCRIPTION
I hope I made this right...

This PR would allow a `defaultText` option to exist alongside the already available `defaultIcon` and `defaultPing` ones.
The option can be quite useful for people who may want to add some placeholder text for the slots, rather than having them empty.