### PR TITLE
Use proper boolean values in jsonBuilder

### DIFF
--- a/config/src/main/java/de/codecrafter47/taboverlay/config/misc/ChatFormat.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/misc/ChatFormat.java
@@ -89,19 +89,19 @@ public class ChatFormat {
                         jsonBuilder.append(",\"font\":\"").append(font).append("\"");
                     }
                     if (bold) {
-                        jsonBuilder.append(",\"bold\":\"true\"");
+                        jsonBuilder.append(",\"bold\":true");
                     }
                     if (italic) {
-                        jsonBuilder.append(",\"italic\":\"true\"");
+                        jsonBuilder.append(",\"italic\":true");
                     }
                     if (underlined) {
-                        jsonBuilder.append(",\"underlined\":\"true\"");
+                        jsonBuilder.append(",\"underlined\":true");
                     }
                     if (strikeout) {
-                        jsonBuilder.append(",\"strikethrough\":\"true\"");
+                        jsonBuilder.append(",\"strikethrough\":true");
                     }
                     if (obfuscated) {
-                        jsonBuilder.append(",\"obfuscated\":\"true\"");
+                        jsonBuilder.append(",\"obfuscated\":true");
                     }
                     jsonBuilder.append("}");
                     builder.setLength(0);
@@ -158,19 +158,19 @@ public class ChatFormat {
                 jsonBuilder.append(",\"font\":\"").append(font).append("\"");
             }
             if (bold) {
-                jsonBuilder.append(",\"bold\":\"true\"");
+                jsonBuilder.append(",\"bold\":true");
             }
             if (italic) {
-                jsonBuilder.append(",\"italic\":\"true\"");
+                jsonBuilder.append(",\"italic\":true");
             }
             if (underlined) {
-                jsonBuilder.append(",\"underlined\":\"true\"");
+                jsonBuilder.append(",\"underlined\":true");
             }
             if (strikeout) {
-                jsonBuilder.append(",\"strikethrough\":\"true\"");
+                jsonBuilder.append(",\"strikethrough\":true");
             }
             if (obfuscated) {
-                jsonBuilder.append(",\"obfuscated\":\"true\"");
+                jsonBuilder.append(",\"obfuscated\":true");
             }
             jsonBuilder.append("}");
             builder.setLength(0);


### PR DESCRIPTION
The ComponentSerializer now strictly checks the JSON format as well as booleans, this leads to losing text format properties in setTextInternal. Confirmed and fixed on my side, MC 1.20.4 and the current master branch 3deaaad of BungeeCord.