### PR TITLE
Add possible fix for finding tokens in words

### DIFF
--- a/config/src/main/java/de/codecrafter47/taboverlay/config/expression/token/PatternTokenReader.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/expression/token/PatternTokenReader.java
@@ -42,7 +42,7 @@ public class PatternTokenReader extends TokenReader {
     public Token read(String text, ParsePosition position, Mark mark, TemplateCreationContext tcc) {
         if (text.regionMatches(ignoreCase, position.getIndex(), pattern, 0, pattern.length())) {
             int newIndex = position.getIndex() + pattern.length();
-            if (((newIndex + 1) < text.length() && text.charAt(newIndex + 1) == ' ') || (newIndex == (text.length() - 1))) {
+            if (((newIndex + 1) < text.length() && Character.isWhitespace(text.charAt(newIndex + 1))) || (newIndex == (text.length() - 1))) {
                 position.setIndex(position.getIndex() + pattern.length());
                 return token;
             }

--- a/config/src/main/java/de/codecrafter47/taboverlay/config/expression/token/PatternTokenReader.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/expression/token/PatternTokenReader.java
@@ -41,8 +41,11 @@ public class PatternTokenReader extends TokenReader {
     @Override
     public Token read(String text, ParsePosition position, Mark mark, TemplateCreationContext tcc) {
         if (text.regionMatches(ignoreCase, position.getIndex(), pattern, 0, pattern.length())) {
-            position.setIndex(position.getIndex() + pattern.length());
-            return token;
+            int newIndex = position.getIndex() + pattern.length();
+            if (((newIndex + 1) < text.length() && text.charAt(newIndex + 1) == ' ') || (newIndex == (text.length() - 1))) {
+                position.setIndex(position.getIndex() + pattern.length());
+                return token;
+            }
         }
         return null;
     }


### PR DESCRIPTION
The PatternTokenReader has a minor flaw where it can find a matching pattern inside a word, meaning that it isn't truly the pattern, but part of a word.

Giving an example with my username (Andre601), if I was to apply the different token readers on it would the "and" token reader return a success, since it found `and` inside my name.

With this PR, this *hopefully* should fix the issue by checking the text length and if the next character after the pattern matches a whitespace (or if the pattern is at the end of a string).

Not sure if my logic here is correct or if I made a mistake anywhere, so testing is recommended and apreciated.