### PR TITLE
Add custom long text cropping feature

### DIFF
--- a/config/src/main/java/de/codecrafter47/taboverlay/config/dsl/AbstractTabOverlayTemplateConfiguration.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/dsl/AbstractTabOverlayTemplateConfiguration.java
@@ -69,6 +69,8 @@ public abstract class AbstractTabOverlayTemplateConfiguration<T extends Abstract
     private Map<MarkedStringProperty, PlayerSetConfiguration> playerSets = new HashMap<>();
 
     private BasicComponentConfiguration.LongTextBehaviour longText = BasicComponentConfiguration.LongTextBehaviour.DISPLAY_ALL;
+    
+    private String customLongText = "";
 
     public T toTemplate(TemplateCreationContext tcc) {
         T template = createTemplate();
@@ -196,6 +198,7 @@ public abstract class AbstractTabOverlayTemplateConfiguration<T extends Abstract
         }
 
         tcc.setDefaultLongTextBehaviour(longText);
+        tcc.setCustomLongText(customLongText);
 
     }
 }

--- a/config/src/main/java/de/codecrafter47/taboverlay/config/dsl/components/BasicComponentConfiguration.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/dsl/components/BasicComponentConfiguration.java
@@ -46,6 +46,7 @@ public class BasicComponentConfiguration extends MarkedPropertyBase implements C
     private PingTemplateConfiguration ping = PingTemplateConfiguration.DEFAULT;
     private Alignment alignment = Alignment.LEFT;
     private LongTextBehaviour longText = null;
+    private String customLongText = null;
 
     private transient boolean needToFixMark = false;
 
@@ -88,6 +89,7 @@ public class BasicComponentConfiguration extends MarkedPropertyBase implements C
                 .rightText(rightTemplate)
                 .ping(ping != null ? ping.toTemplate(tcc) : tcc.getDefaultPing())
                 .longText(Optional.ofNullable(longText).orElse(tcc.getDefaultLongTextBehaviour().orElse(LongTextBehaviour.DISPLAY_ALL)))
+                .customLongText(Optional.ofNullable(customLongText).orElse(tcc.getDefaultCustomLongText().orElse("")))
                 .build();
     }
 
@@ -96,6 +98,6 @@ public class BasicComponentConfiguration extends MarkedPropertyBase implements C
     }
 
     public enum LongTextBehaviour {
-        DISPLAY_ALL, CROP, CROP_2DOTS, CROP_3DOTS;
+        DISPLAY_ALL, CROP, CROP_2DOTS, CROP_3DOTS, CUSTOM;
     }
 }

--- a/config/src/main/java/de/codecrafter47/taboverlay/config/template/TemplateCreationContext.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/template/TemplateCreationContext.java
@@ -76,6 +76,8 @@ public class TemplateCreationContext implements Cloneable {
     private PlayerSetConfiguration.Visibility defaultHiddenPlayerVisibility = PlayerSetConfiguration.Visibility.VISIBLE_TO_ADMINS;
 
     private BasicComponentConfiguration.LongTextBehaviour defaultLongTextBehaviour = null;
+    
+    private String customLongText = null;
 
     private boolean viewerAvailable = false;
 
@@ -92,6 +94,10 @@ public class TemplateCreationContext implements Cloneable {
 
     public Optional<BasicComponentConfiguration.LongTextBehaviour> getDefaultLongTextBehaviour() {
         return Optional.ofNullable(defaultLongTextBehaviour);
+    }
+    
+    public Optional<String> getDefaultCustomLongText(){
+        return Optional.ofNullable(customLongText);
     }
 
     public ComponentTemplate emptySlot() {

--- a/config/src/main/java/de/codecrafter47/taboverlay/config/template/component/BasicComponentTemplate.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/template/component/BasicComponentTemplate.java
@@ -35,6 +35,7 @@ public class BasicComponentTemplate implements ComponentTemplate {
     PingTemplate ping;
     IconTemplate icon;
     BasicComponentConfiguration.LongTextBehaviour longText;
+    String customLongText;
 
     @Override
     public LayoutInfo getLayoutInfo() {
@@ -50,6 +51,6 @@ public class BasicComponentTemplate implements ComponentTemplate {
         return new BasicComponentView(leftText != null ? leftText.instantiate() : null,
                 centerText != null ? centerText.instantiate() : null,
                 rightText != null ? rightText.instantiate() : null,
-                ping.instantiate(), icon.instantiate(), longText);
+                ping.instantiate(), icon.instantiate(), longText, customLongText);
     }
 }

--- a/config/src/main/java/de/codecrafter47/taboverlay/config/view/components/BasicComponentView.java
+++ b/config/src/main/java/de/codecrafter47/taboverlay/config/view/components/BasicComponentView.java
@@ -39,19 +39,21 @@ public final class BasicComponentView extends ComponentView implements TextViewU
     private final PingView pingView;
     private final IconView iconView;
     private final BasicComponentConfiguration.LongTextBehaviour longText;
+    private final String customLongText;
     private int slotWidth;
     @Nullable
     private UUID uuid;
     @Nullable
     private String textAfterAlignment;
 
-    public BasicComponentView(TextView leftTextView, TextView centerTextView, TextView rightTextView, PingView pingView, IconView iconView, BasicComponentConfiguration.LongTextBehaviour longText) {
+    public BasicComponentView(TextView leftTextView, TextView centerTextView, TextView rightTextView, PingView pingView, IconView iconView, BasicComponentConfiguration.LongTextBehaviour longText, String customLongText) {
         this.leftTextView = leftTextView;
         this.centerTextView = centerTextView;
         this.rightTextView = rightTextView;
         this.pingView = pingView;
         this.iconView = iconView;
         this.longText = longText;
+        this.customLongText = customLongText;
     }
 
     @Override
@@ -104,6 +106,8 @@ public final class BasicComponentView extends ComponentView implements TextViewU
                     suffix = "..";
                 } else if (longText == BasicComponentConfiguration.LongTextBehaviour.CROP_3DOTS) {
                     suffix = "...";
+                } else if (longText == BasicComponentConfiguration.LongTextBehaviour.CUSTOM) {
+                    suffix = customLongText;
                 }
                 float suffixLength = ChatFormat.formattedTextLength(suffix);
                 leftText = ChatFormat.cropFormattedText(leftText, slotWidth - ((rightTextView != null ? 4f : 0f) + rightTextLength) - suffixLength) + suffix;


### PR DESCRIPTION
I most likely missed some key places to update, but this should in theory add support for setting `longText` to `CUSTOM` with an additional `customLongText` option to set.

When set to custom would it take the `customLongText` value (Empty String by default) to then set the suffix to use when cropping text, allowing more freedom in how names should be cropped.

This effectively implements what [I've suggested a long time ago](https://github.com/CodeCrafter47/BungeeTabListPlus/issues/457).
